### PR TITLE
fix(tooltip): tooltip sample not working with keyboard navigation.

### DIFF
--- a/src/material-examples/tooltip-manual/tooltip-manual-example.html
+++ b/src/material-examples/tooltip-manual/tooltip-manual-example.html
@@ -2,18 +2,21 @@
   <span> Mouse over to </span>
   <button mat-button
           (mouseenter)="tooltip.show()"
+          (keyup.enter)="tooltip.show()"
           aria-label="Button that progamatically shows a tooltip on another button"
           class="example-action-button">
     show
   </button>
   <button mat-button
           (mouseenter)="tooltip.hide()"
+          (keyup.enter)="tooltip.hide()"
           aria-label="Button that progamatically hides a tooltip on another button"
           class="example-action-button">
     hide
   </button>
   <button mat-button
           (mouseenter)="tooltip.toggle()"
+          (keyup.enter)="tooltip.toggle()"
           aria-label="Button that progamatically toggles a tooltip on another button to show/hide"
           class="example-action-button">
     toggle show/hide


### PR DESCRIPTION
Tooltip showing/hiding in sample when enter key is pressed.
Fixes #15044